### PR TITLE
Change composer package name for repo name parity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wikimedia/interconnection",
+    "name": "wikimedia/interconnection-wordpress-theme",
     "type": "wordpress-theme",
     "description": "Interconnection is a theme based on http://underscores.me/ intended for use on the Wikimedia Diff blog.",
     "keywords": [


### PR DESCRIPTION
This matches how `shiro` works, which uses both the repository name and package name `shiro-wordpress-theme`.