### PR TITLE
752: Sticky Post Appears in Diff Homepage Grid When it Should be Excluded

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -449,8 +449,6 @@ function interconnection_change_publish_button_js() {
  * so we can replace translated content in the loop. This allows
  * us to display English posts if the posts are not translated.
  *
- * This function also removes the sticky post from the homepage loop.
- *
  * @param WP_Query $query The WP_Query instance (passed by reference).
  */
 function interconnection_modify_polylang_query( $query ) {
@@ -458,11 +456,23 @@ function interconnection_modify_polylang_query( $query ) {
 	if ( function_exists( 'pll__' ) && ! is_admin() && ! is_singular() && $query->is_main_query() ) {
 		$languages = pll_default_language() . ',' . pll_current_language();
 		$query->set( 'lang', $languages );
-
-		// Remove sticky posts from homepage loop.
-		if ( is_home() ) {
-			$query->set( 'post__not_in', get_option( 'sticky_posts' ) ); // phpcs:ignore
-		}
 	}
 }
 //add_action( 'pre_get_posts', 'interconnection_modify_polylang_query' );
+
+/**
+ * Remove the sticky post from the homepage loop.
+ *
+ * @param WP_Query $query The WP_Query instance (passed by reference).
+ */
+function interconnection_remove_homepage_sticky_posts( $query ) {
+	// Get the last added sticky post - last in array.
+	$sticky            = get_option( 'sticky_posts' );
+	$exclude_from_grid = $sticky ? array( $sticky[ count( $sticky ) - 1 ] ) : '';
+
+	if ( ! is_admin() && is_home() && $query->is_main_query() ) {
+		$query->set( 'ignore_sticky_posts', true );
+		$query->set( 'post__not_in', $exclude_from_grid );
+	}
+}
+add_action( 'pre_get_posts', 'interconnection_remove_homepage_sticky_posts' );

--- a/functions.php
+++ b/functions.php
@@ -472,7 +472,10 @@ function interconnection_remove_homepage_sticky_posts( $query ) {
 
 	if ( ! is_admin() && is_home() && $query->is_main_query() ) {
 		$query->set( 'ignore_sticky_posts', true );
-		$query->set( 'post__not_in', $exclude_from_grid );
+
+		if ( ! empty( $exclude_from_grid ) ) {
+			$query->set( 'post__not_in', $exclude_from_grid );
+		}
 	}
 }
 add_action( 'pre_get_posts', 'interconnection_remove_homepage_sticky_posts' );

--- a/index.php
+++ b/index.php
@@ -25,7 +25,12 @@ get_header();
 			// Use the last added sticky post - last in array.
 			// We must use ignore_sticky_posts alongside post__in, because
 			// WP_Query will always retrieve all sticky posts vs just the latest.
-			$the_query = new WP_Query( array( 'post__in' => $exclude_from_grid, 'ignore_sticky_posts' => true ) );
+			$the_query = new WP_Query(
+				array(
+					'ignore_sticky_posts' => true,
+					'post__in'            => $exclude_from_grid,
+				)
+			);
 
 			while ( $the_query->have_posts() ) :
 				$the_query->the_post();

--- a/index.php
+++ b/index.php
@@ -23,8 +23,9 @@ get_header();
 
 		if ( is_home() && ! empty( $sticky ) && ! is_paged() ) :
 			// Use the last added sticky post - last in array.
-			$the_query         = new WP_Query( array( 'post__in' => $exclude_from_grid ) );
-			$exclude_from_grid = array( $sticky[ count( $sticky ) - 1 ] );
+			// We must use ignore_sticky_posts alongside post__in, because
+			// WP_Query will always retrieve all sticky posts vs just the latest.
+			$the_query = new WP_Query( array( 'post__in' => $exclude_from_grid, 'ignore_sticky_posts' => true ) );
 
 			while ( $the_query->have_posts() ) :
 				$the_query->the_post();


### PR DESCRIPTION
This change removes the sticky posts from the homepage grid loop. It also ensures that if more than one sticky posts exist, only the latest one is shown on top of the grid.

**Testing Instructions:**

1. Assign a post as a sticky post
2. Navigate to the Diff homepage
4. Check that only one sticky post (the latest one added) is featured on top of the homepage article grid
5. Check that the sticky post just added is not included in the homepage article grid

For humanmade/Wikimedia/issues/752.