### PR TITLE
327: Add Styles for Custom Event Language Selector Block

### DIFF
--- a/sass/3-elements/_blocks.scss
+++ b/sass/3-elements/_blocks.scss
@@ -1,0 +1,8 @@
+/* Event Language Selector */
+
+.wp-block-interconnection-event-language {
+	h1, h2, h3, h4, h5, h6 {
+		line-height: 1;
+		margin-bottom: 5px;
+	}
+}

--- a/sass/3-elements/_elements.scss
+++ b/sass/3-elements/_elements.scss
@@ -33,3 +33,5 @@ figure {
 }
 
 @import "tables";
+
+@import "blocks";

--- a/style.css
+++ b/style.css
@@ -547,6 +547,17 @@ td {
 	border: 0.05rem solid #c8ccd1;
 }
 
+/* Event Language Selector */
+.wp-block-interconnection-event-language h1,
+.wp-block-interconnection-event-language h2,
+.wp-block-interconnection-event-language h3,
+.wp-block-interconnection-event-language h4,
+.wp-block-interconnection-event-language h5,
+.wp-block-interconnection-event-language h6 {
+	line-height: 1;
+	margin-bottom: 5px;
+}
+
 .wrapper {
 	max-width: 75rem;
 	padding: 0 2rem;


### PR DESCRIPTION
This change adds front-end styles for the custom "Primary Event Language" block that allows users to select a language for the event they are creating.

For humanmade/wikimedia#327