### PR TITLE
769: Look up description from linked User on guest-author archives

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -59,3 +59,41 @@ function interconnection_show_author_description_in_byline( $link_args, $author 
 	return $link_args;
 }
 add_filter( 'coauthors_posts_link', 'interconnection_show_author_description_in_byline', 10, 2 );
+
+/**
+ * Use a linked user account's "description" when showing a guest author archive,
+ * and fall back to the guest author's biography field.
+ *
+ * @param string $description Archive description to be displayed.
+ * @return string Filtered archive description.
+ */
+function interconnection_cap_description( $description ) : string {
+	// No action for non-authors, or authors with descriptions.
+	if ( ! is_author() || ! empty( $description ) ) {
+		return $description;
+	}
+
+	// Only process guest authors.
+	$queried_object = get_queried_object();
+	if ( $queried_object->type !== 'guest-author' ) {
+		return $description;
+	}
+
+	// Look up linked user record, if present.
+	$linked_user = get_user_by( 'login', $queried_object->linked_account );
+	if ( ! empty( $linked_user ) ) {
+		$description = get_the_author_meta( 'description', $linked_user->ID );
+		if ( ! empty( $description ) ) {
+			return $description;
+		}
+	}
+
+	// Finally, try to read from CAP record and return the guest author bio field.
+	$description = get_post_meta( $queried_object->ID, 'cap-description', true ) ?: '';
+	if ( ! empty( $description ) ) {
+		return $description;
+	}
+
+	return $description;
+}
+add_filter( 'get_the_archive_description', 'interconnection_cap_description' );


### PR DESCRIPTION
When a guest-author page is being rendered, it seems that CAP isn't consistently looking up the linked author's description if CAP's own description field is empty. This PR manually fetches the bio information from the linked user, when present.

Testing instructions

1. Find a guest author who is linked to a regular user
2. Make sure the user has a "description" filled in in their user page for the current language
3. See that when viewing the archives for the guest author, the user's description is shown