### PR TITLE
Fix to force bylines to be LTR direction to avoid problems on RTL langs

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -24,7 +24,7 @@ if ( ! function_exists( 'interconnection_posted_on' ) ) :
 			esc_attr( get_the_modified_date( DATE_W3C ) ),
 			esc_html( get_the_modified_date() )
 		);
-
+	
 		echo '<span class="posted-on">' . $time_string . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
@@ -43,9 +43,9 @@ if ( ! function_exists( 'interconnection_posted_by' ) ) :
 
 		if ( function_exists( 'coauthors_posts_links' ) ) {
 			$authors = coauthors_posts_links( null, null, 'by ', null, false );
-			echo '<span class="byline" dir="ltr"> ' . $authors . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<span class="byline"> ' . $authors . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
-			echo '<span class="byline" dir="ltr"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<span class="byline"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 	}
@@ -139,7 +139,7 @@ if ( ! function_exists( 'interconnection_post_thumbnail' ) ) :
 					<div class="home-thumbnail"></div>
 			</a>
 			<?php };
-
+			
 		endif; // End is_singular().
 	}
 endif;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -24,7 +24,7 @@ if ( ! function_exists( 'interconnection_posted_on' ) ) :
 			esc_attr( get_the_modified_date( DATE_W3C ) ),
 			esc_html( get_the_modified_date() )
 		);
-	
+
 		echo '<span class="posted-on">' . $time_string . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
@@ -43,9 +43,9 @@ if ( ! function_exists( 'interconnection_posted_by' ) ) :
 
 		if ( function_exists( 'coauthors_posts_links' ) ) {
 			$authors = coauthors_posts_links( null, null, 'by ', null, false );
-			echo '<span class="byline"> ' . $authors . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<span class="byline" dir="ltr"> ' . $authors . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
-			echo '<span class="byline"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<span class="byline" dir="ltr"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 	}
@@ -139,7 +139,7 @@ if ( ! function_exists( 'interconnection_post_thumbnail' ) ) :
 					<div class="home-thumbnail"></div>
 			</a>
 			<?php };
-			
+
 		endif; // End is_singular().
 	}
 endif;

--- a/template-parts/content-grid.php
+++ b/template-parts/content-grid.php
@@ -40,7 +40,7 @@ if ( is_rtl() ) {
 	</header><!-- .entry-header -->
 
 	<?php if ( 'post' === get_post_type() ) : ?>
-		<div class="entry-meta">
+		<div class="entry-meta" <?php echo $rtl_css_override; ?>>
 			<?php
 			interconnection_posted_on();
 			interconnection_posted_by();

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -39,6 +39,17 @@ if ( function_exists( 'pll_the_languages' ) ) {
 	$languages = array_combine( $language_slugs, $language_names );
 }
 
+// Define rtl CSS override for entry title.
+//
+// This ensures that the $lang_title string displays before
+// the post title on rtl languages. We don't add the CSS to
+// style.css because when style-rtl.css gets automatically
+// generated the values would get reversed.
+$rtl_css_override = '';
+if ( is_rtl() ) {
+	$rtl_css_override = ' style="direction:ltr; text-align:right;"';
+}
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -53,7 +64,7 @@ if ( function_exists( 'pll_the_languages' ) ) {
 
 			if ( 'post' === get_post_type() ) :
 				?>
-				<div class="entry-meta">
+				<div class="entry-meta" <?php echo $rtl_css_override; ?>>
 					<?php
 					interconnection_posted_on();
 					interconnection_posted_by();

--- a/template-parts/modules/featured-post.php
+++ b/template-parts/modules/featured-post.php
@@ -9,6 +9,17 @@
 
 $permalink = get_permalink();
 
+// Define rtl CSS override for entry title.
+//
+// This ensures that the $lang_title string displays before
+// the post title on rtl languages. We don't add the CSS to
+// style.css because when style-rtl.css gets automatically
+// generated the values would get reversed.
+$rtl_css_override = '';
+if ( is_rtl() ) {
+	$rtl_css_override = ' style="direction:ltr; text-align:right;"';
+}
+
 ?>
 <article class="featured-post grid-post" id="post-<?php the_ID(); ?>" <?php post_class(); ?> >
 	<div class="featured-post-image">
@@ -21,7 +32,7 @@ $permalink = get_permalink();
 		</header><!-- .entry-header -->
 
 		<?php if ( 'post' === get_post_type() ) : ?>
-			<div class="entry-meta">
+			<div class="entry-meta" <?php echo $rtl_css_override; ?>>
 				<?php
 				interconnection_posted_on();
 				interconnection_posted_by();


### PR DESCRIPTION
This PR intends to force bylines to be LTR oriented, as some errors are being displayed when those bylines are displayed on RTL languages.

## Testing instructions
Access https://wikimediadiff.vipdev.lndo.site/ar/2022/12/06/%D8%A7%D9%84%D8%AA%D8%B5%D9%88%D9%8A%D8%AA-%D9%84%D8%B5%D9%88%D8%AA-%D8%A7%D9%84%D9%85%D8%B9%D8%B1%D9%81%D8%A9-%D8%A7%D9%84%D8%A5%D9%86%D8%B3%D8%A7%D9%86%D9%8A%D9%8E%D9%91%D8%A9-%D9%83%D9%84%D9%87/ and check if byline is being displayed correctly.
