### PR TITLE
Fix undefined index warning in sticky posts logic

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -468,14 +468,15 @@ function interconnection_modify_polylang_query( $query ) {
 function interconnection_remove_homepage_sticky_posts( $query ) {
 	// Get the last added sticky post - last in array.
 	$sticky            = get_option( 'sticky_posts' );
-	$exclude_from_grid = $sticky ? array( $sticky[ count( $sticky ) - 1 ] ) : '';
+	$exclude_from_grid = is_array( $sticky ) ? array_pop( $sticky ) : '';
 
 	if ( ! is_admin() && is_home() && $query->is_main_query() ) {
 		$query->set( 'ignore_sticky_posts', true );
 
 		if ( ! empty( $exclude_from_grid ) ) {
-			$query->set( 'post__not_in', $exclude_from_grid );
+			$query->set( 'post__not_in', [ $exclude_from_grid ] );
 		}
 	}
 }
+
 add_action( 'pre_get_posts', 'interconnection_remove_homepage_sticky_posts' );


### PR DESCRIPTION
This avoids an undefined index warning thrown in the theme after #6 if there aren't sticky posts set:

>  PHP Notice:  Undefined offset: 1 in /srv/www/diffblog/public_html/wp-content/themes/interconnection/functions.php on line 471