### PR TITLE
#774: Add Attachment Page Template

### DIFF
--- a/inc/classes/class-credits.php
+++ b/inc/classes/class-credits.php
@@ -83,6 +83,50 @@ class Credits {
 	}
 
 	/**
+	 * Retrieve the image credit metadata for a specific attachment.
+	 *
+	 * @param int $image_id Attachment ID.
+	 * @return array Associative array of [ author, license, license_url, url ] credit data.
+	 */
+	public static function get_image_credits( $image_id ) : array {
+		$credit_info  = get_post_meta( $image_id, 'credit_info', true );
+		$author       = ! empty( $credit_info['author'] ) ? $credit_info['author'] : '';
+		$license      = ! empty( $credit_info['license'] ) ? $credit_info['license'] : '';
+		$url          = ! empty( $credit_info['url'] ) ? $credit_info['url'] : '';
+
+		if ( is_int( stripos( $license, 'Public domain' ) ) ) {
+			$license_url = 'https://en.wikipedia.org/wiki/Public_domain';
+		} elseif ( is_int( stripos( $license, 'GFDL' ) ) && is_int( stripos( $license, '1.2' ) ) ) {
+			$license_url = 'https://commons.wikimedia.org/wiki/Commons:GNU_Free_Documentation_License,_version_1.2';
+		} elseif ( is_int( stripos( $license, 'CC0' ) ) ) {
+			$license_url = 'https://creativecommons.org/publicdomain/zero/1.0/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '4.0' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by-sa/4.0/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) & is_int( stripos( $license, '3.0' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by-sa/3.0/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) & is_int( stripos( $license, '2.0' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by-sa/2.0/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '4.0' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by/4.0/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '3.0' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by/3.0/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.5' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by/2.5/';
+		} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.0' ) ) ) {
+			$license_url = 'https://creativecommons.org/licenses/by/2.0/';
+		} else {
+			$license_url = ! empty( $credit_info['license_url'] ) ? $credit_info['license_url'] : '';
+		}
+
+		return [
+			'author'      => $author,
+			'license'     => $license,
+			'license_url' => $license_url,
+			'url'         => $url,
+		];
+	}
+
+	/**
 	 * Pauses capture of the image_ids.
 	 */
 	public function pause() {

--- a/sass/8-site/primary/_posts-and-pages.scss
+++ b/sass/8-site/primary/_posts-and-pages.scss
@@ -336,3 +336,10 @@ article.page h6[id]::before {
 
 	@include margin-bottom(0);
 }
+
+body.attachment {
+
+	.entry-meta p:not(:last-child) {
+		margin-bottom: 0;
+	}
+}

--- a/template-parts/content-attachment.php
+++ b/template-parts/content-attachment.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Template part for displaying attachment page
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package Interconnection
+ */
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<div class="wrapper">
+
+		<header class="entry-header">
+			<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+		</header>
+
+		<div class="entry-content">
+			<div class="main-entry-content">
+				<?php
+					$image_size = apply_filters( 'wporg_attachment_size', 'large' );
+					echo wp_kses( wp_get_attachment_image( get_the_ID(), $image_size ), 'post' );
+				?>
+			</div>
+		</div>
+
+	</div>
+
+</article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/content-attachment.php
+++ b/template-parts/content-attachment.php
@@ -7,6 +7,12 @@
  * @package Interconnection
  */
 
+$credit_info  = Interconnection\Credits::get_image_credits( get_the_ID() );
+$author       = $credit_info['author'] ?? '';
+$license      = $credit_info['license'] ?? '';
+$license_url  = $credit_info['license_url'] ?? '';
+$url          = $credit_info['url'];
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -17,6 +23,22 @@
 			<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 		</header>
 
+		<div class="entry-meta">
+			<?php if ( ! empty( $author ) ) : ?>
+				<p class="credit"><?php echo esc_html( $author ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( ! empty( $license ) ) : ?>
+				<p class="credit-desc" >
+					<?php if ( ! empty( $license_url ) ) : ?>
+						<a href="<?php echo esc_url( $license_url ); ?>" target="_blank">
+					<?php endif; ?>
+							<?php echo esc_html( $license ); ?>
+					<?php if ( ! empty( $license_url ) ) : ?>
+						</a>
+					<?php endif; ?></p>
+			<?php endif; ?>
+		</div>
 		<div class="entry-content">
 			<div class="main-entry-content">
 				<?php

--- a/template-parts/images/credit.php
+++ b/template-parts/images/credit.php
@@ -20,34 +20,11 @@ if ( empty( $attachment ) || ! $img_url ) {
 
 $credit_title = $attachment->post_title;
 $description  = $attachment->post_content;
-$credit_info  = get_post_meta( $image_id, 'credit_info', true );
-$author       = ! empty( $credit_info['author'] ) ? $credit_info['author'] : '';
-$license      = ! empty( $credit_info['license'] ) ? $credit_info['license'] : '';
-$url          = ! empty( $credit_info['url'] ) ? $credit_info['url'] : '';
-
-if ( is_int( stripos( $license, 'Public domain' ) ) ) {
-	$license_url = 'https://en.wikipedia.org/wiki/Public_domain';
-} elseif ( is_int( stripos( $license, 'GFDL' ) ) && is_int( stripos( $license, '1.2' ) ) ) {
-	$license_url = 'https://commons.wikimedia.org/wiki/Commons:GNU_Free_Documentation_License,_version_1.2';
-} elseif ( is_int( stripos( $license, 'CC0' ) ) ) {
-	$license_url = 'https://creativecommons.org/publicdomain/zero/1.0/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '4.0' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by-sa/4.0/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) & is_int( stripos( $license, '3.0' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by-sa/3.0/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) & is_int( stripos( $license, '2.0' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by-sa/2.0/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '4.0' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by/4.0/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '3.0' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by/3.0/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.5' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by/2.5/';
-} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.0' ) ) ) {
-	$license_url = 'https://creativecommons.org/licenses/by/2.0/';
-} else {
-	$license_url = ! empty( $credit_info['license_url'] ) ? $credit_info['license_url'] : '';
-}
+$credit_info  = Interconnection\Credits::get_image_credits( $image_id );
+$author       = $credit_info['author'] ?? '';
+$license      = $credit_info['license'] ?? '';
+$license_url  = $credit_info['license_url'] ?? '';
+$url          = $credit_info['url'];
 ?>
 
 <div class="photo-credit-container flex flex-all flex-wrap">


### PR DESCRIPTION
This pull request introduces a new template part for displaying attachment pages, allowing a more consistent and customized view for attachments within the theme.

### Changes included
- A new file `content-attachment.php` that contains the HTML structure and PHP logic for rendering attachment pages.

### Testing instructions
- Navigate to a page which has an attachment, and the link is set for something like `https://wikimediadiff.vipdev.lndo.site/?attachment_id=89030`
- Verify that the new attachment page template is loaded and that it displays the attachment correctly.
- Confirm that the styling and layout match the rest of the theme.

### Screenshot
![image](https://github.com/wikimedia/interconnection-wordpress-theme/assets/90911997/e04218c1-ffe9-44e4-9032-1e860ce671a0)
