### PR TITLE
#879: Lock Polylang Content Duplication to Enabled

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -109,13 +109,21 @@ add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
  */
 function filter_pll_duplicate_content( $check, $user_id, $meta_key, $meta_value ) {
 	if ( $meta_key === 'pll_duplicate_content' ) {
-		$meta_value['post'] = true;
-		update_user_meta( $user_id, $meta_key, $meta_value );
-		return false;
+		// Disable filters.
+		remove_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10 );
+		remove_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10 );
+
+		// Update the meta value.
+		update_user_meta( $user_id, 'pll_duplicate_content', [ 'post' => true ] );
+
+		// Re-enable filters.
+		add_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
+		add_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
+
+		return false; // Prevent the regular update.
 	}
 
-	return null;
+	return null; // Allow the regular update.
 }
 add_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
 add_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
-

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -97,3 +97,21 @@ function interconnection_cap_description( $description ) : string {
 	return $description;
 }
 add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
+
+
+/**
+ * Toggles Polylang Content duplication for the current user.
+ *
+ * This function updates the 'pll_duplicate_content' user meta to control content duplication
+ * across languages in Polylang. The feature is controlled by the 'pll-duplicate' option,
+ * and when enabled, it allows the content to be duplicated across different languages.
+ *
+ * It makes the link https://<environment>/wp-admin/post-new.php?post_type=post&from_post=<POST-ID>&new_lang=<LANG>&_wpnonce=<NONCE>
+ * to create a new post in the language specified by the 'new_lang' parameter.
+ *
+ * See #879 Diff bug ticket for more details.
+ */
+function toggle_polylang_content_duplication() {
+    update_user_meta( get_current_user_id(), 'pll_duplicate_content', [ 'post' => true ] );
+}
+add_action( 'init', 'toggle_polylang_content_duplication' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -98,27 +98,14 @@ function interconnection_cap_description( $description ) : string {
 }
 add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
 
-
-/**
- * Locks Polylang Content duplication for the current user.
- *
- * This function updates the 'pll_duplicate_content' user meta to 'true'
- * whenever WordPress finishes updating any user data - when enabled, it
- * allows the content to be duplicated across different languages.
- *
- * It makes the link https://<environment>/wp-admin/post-new.php?post_type=post&from_post=<POST-ID>&new_lang=<LANG>&_wpnonce=<NONCE>
- * to create a new post in the language specified by the 'new_lang' parameter.
- *
- * See #879 Diff bug ticket for more details.
- */
-function update_polylang_content_duplication( $user_id ) {
-	// If Polylang is not active, exit early.
-	if ( ! function_exists( 'pll_is_translated_post_type' ) ) {
-		return;
+// TODO: docblock this
+function filter_pll_duplicate_content( $value, $user_id, $meta_key, $single ) {
+	if ( 'pll_duplicate_content' === $meta_key ) {
+		return [ 'post' => true ];
 	}
 
-	// Update the user meta to enable content duplication across languages.
-	update_user_meta( $user_id, 'pll_duplicate_content', [ 'post' => true ] );
-}
-add_action( 'profile_update', 'update_polylang_content_duplication', 10, 1 ); // Hook into the profile update.
-add_action( 'user_register', 'update_polylang_content_duplication', 10, 1 ); // Hook into user registration.
+	return $value;
+
+add_filter( 'get_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
+
+

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -110,8 +110,10 @@ add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
 function force_pll_duplicate_content_metadata_value( $value, int $object_id, string $meta_key ) {
 	if ( $meta_key === 'pll_duplicate_content' ) {
 		return [
-			'post' => true,
-			'page' => true,
+			[
+				'post' => true,
+				'page' => true,
+			]
 		];
 	}
 	return $value;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -98,14 +98,24 @@ function interconnection_cap_description( $description ) : string {
 }
 add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
 
-// TODO: docblock this
-function filter_pll_duplicate_content( $value, $user_id, $meta_key, $single ) {
-	if ( 'pll_duplicate_content' === $meta_key ) {
-		return [ 'post' => true ];
+/**
+ * Ensures that the 'pll_duplicate_content' user meta is always set to true.
+ *
+ * @param null|bool  $check      Whether to allow adding/updating metadata of the given type.
+ * @param int        $user_id    User ID.
+ * @param string     $meta_key   Meta key.
+ * @param mixed      $meta_value Meta value.
+ * @return null|bool Null to allow adding/updating metadata, false to prevent it.
+ */
+function filter_pll_duplicate_content( $check, $user_id, $meta_key, $meta_value ) {
+	if ( $meta_key === 'pll_duplicate_content' ) {
+		$meta_value['post'] = true;
+		update_user_meta( $user_id, $meta_key, $meta_value );
+		return false;
 	}
 
-	return $value;
-
-add_filter( 'get_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
-
+	return null;
+}
+add_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
+add_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -100,35 +100,25 @@ add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
 
 
 /**
- * Toggles Polylang Content duplication for the current user.
+ * Locks Polylang Content duplication for the current user.
  *
- * This function updates the 'pll_duplicate_content' user meta to control content duplication
- * across languages in Polylang. The feature is controlled by the 'pll-duplicate' option,
- * and when enabled, it allows the content to be duplicated across different languages.
+ * This function updates the 'pll_duplicate_content' user meta to 'true'
+ * whenever WordPress finishes updating any user data - when enabled, it
+ * allows the content to be duplicated across different languages.
  *
  * It makes the link https://<environment>/wp-admin/post-new.php?post_type=post&from_post=<POST-ID>&new_lang=<LANG>&_wpnonce=<NONCE>
  * to create a new post in the language specified by the 'new_lang' parameter.
  *
  * See #879 Diff bug ticket for more details.
  */
-/**
- * Toggles Polylang content duplication.
- *
- * Ensures that Polylang content duplication is enabled for posts and pages
- * if Polylang is active and the user is on the new post or edit post screen.
- */
-function toggle_polylang_content_duplication() {
-	// Exit earlier if Polylang is not active.
+function update_polylang_content_duplication( $user_id ) {
+	// If Polylang is not active, exit early.
 	if ( ! function_exists( 'pll_is_translated_post_type' ) ) {
 		return;
 	}
 
-	// Also exit if the user isn't on the new post or edit post screen.
-	$post_type = isset( $_GET['post_type'] ) ? sanitize_key( $_GET['post_type'] ) : '';
-	if ( empty( $post_type ) || ! in_array( $post_type, [ 'post', 'page' ], true ) ) {
-		return;
-	}
-
-	update_user_meta( get_current_user_id(), 'pll_duplicate_content', [ 'post' => true ] );
+	// Update the user meta to enable content duplication across languages.
+	update_user_meta( $user_id, 'pll_duplicate_content', [ 'post' => true ] );
 }
-add_action( 'admin_init', 'toggle_polylang_content_duplication' );
+add_action( 'profile_update', 'update_polylang_content_duplication', 10, 1 ); // Hook into the profile update.
+add_action( 'user_register', 'update_polylang_content_duplication', 10, 1 ); // Hook into user registration.

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -111,7 +111,24 @@ add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
  *
  * See #879 Diff bug ticket for more details.
  */
+/**
+ * Toggles Polylang content duplication.
+ *
+ * Ensures that Polylang content duplication is enabled for posts and pages
+ * if Polylang is active and the user is on the new post or edit post screen.
+ */
 function toggle_polylang_content_duplication() {
-    update_user_meta( get_current_user_id(), 'pll_duplicate_content', [ 'post' => true ] );
+	// Exit earlier if Polylang is not active.
+	if ( ! function_exists( 'pll_is_translated_post_type' ) ) {
+		return;
+	}
+
+	// Also exit if the user isn't on the new post or edit post screen.
+	$post_type = isset( $_GET['post_type'] ) ? sanitize_key( $_GET['post_type'] ) : '';
+	if ( empty( $post_type ) || ! in_array( $post_type, [ 'post', 'page' ], true ) ) {
+		return;
+	}
+
+	update_user_meta( get_current_user_id(), 'pll_duplicate_content', [ 'post' => true ] );
 }
-add_action( 'init', 'toggle_polylang_content_duplication' );
+add_action( 'admin_init', 'toggle_polylang_content_duplication' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -101,29 +101,19 @@ add_filter( 'get_the_archive_description', 'interconnection_cap_description' );
 /**
  * Ensures that the 'pll_duplicate_content' user meta is always set to true.
  *
- * @param null|bool  $check      Whether to allow adding/updating metadata of the given type.
- * @param int        $user_id    User ID.
- * @param string     $meta_key   Meta key.
- * @param mixed      $meta_value Meta value.
- * @return null|bool Null to allow adding/updating metadata, false to prevent it.
+ * @param mixed  $value     The value to return, either a single metadata value or an array
+ *                          of values depending on the value of `$single`. Default null.
+ * @param int    $object_id ID of the object metadata is for.
+ * @param string $meta_key  Metadata key.
+ * @return mixed Metadata value override, or unchanged input value.
  */
-function filter_pll_duplicate_content( $check, $user_id, $meta_key, $meta_value ) {
+function force_pll_duplicate_content_metadata_value( $value, int $object_id, string $meta_key ) {
 	if ( $meta_key === 'pll_duplicate_content' ) {
-		// Disable filters.
-		remove_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10 );
-		remove_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10 );
-
-		// Update the meta value.
-		update_user_meta( $user_id, 'pll_duplicate_content', [ 'post' => true ] );
-
-		// Re-enable filters.
-		add_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
-		add_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
-
-		return false; // Prevent the regular update.
+		return [
+			'post' => true,
+			'page' => true,
+		];
 	}
-
-	return null; // Allow the regular update.
+	return $value;
 }
-add_filter( 'update_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
-add_filter( 'add_user_metadata', 'filter_pll_duplicate_content', 10, 4 );
+add_filter( 'get_user_metadata', 'force_pll_duplicate_content_metadata_value', 10, 3 );


### PR DESCRIPTION
## Locks Polylang Content Duplication to Enabled

### Summary
This pull request adds the function `toggle_polylang_content_duplication`, which lock the content duplication feature to "enabled" across different languages in Polylang. By updating the 'pll_duplicate_content' user meta to "enabled," the function ensure that content duplication is always active.

The feature is controlled by this button, now always active:
![image](https://github.com/wikimedia/interconnection-wordpress-theme/assets/90911997/59a1f512-95a6-403e-a250-fab4506c98bf)

When editing a content on WordPress admin, the feature is also expected to work if the toggle gets unchecked by user and user clicks on button "+" on the language sidebar.

### Functionality
- Locks content duplication across languages to "enabled" making the link below to work: 
https://<environment>/wp-admin/post-new.php?post_type=post&from_post=<POST-ID>&new_lang=<LANG>&_wpnonce=<NONCE>

The button annotated on the screenshot below, present on all the content page, leads to a link like this.

![image](https://github.com/wikimedia/interconnection-wordpress-theme/assets/90911997/30949eff-a8d7-4166-9708-0ba8e65a5073)

### Related Ticket
See [#879](https://app.zenhub.com/workspaces/diff-blog-627933ce511a0e001e232ecc/issues/gh/humanmade/wikimedia/879)

### How to Test
1. Access a content page on frontend
2. Find the component "Can you help us translate this article?" (screenshot above)
3. Select a language and click on "Submit" button
4. Verify that content of the article gets copied to the new post
5. On the language sidebar, choose a language and click on "+" button
