### PR TITLE
#887: Fix JetPack Email Author

### DIFF
--- a/inc/authors.php
+++ b/inc/authors.php
@@ -104,7 +104,7 @@ function redirect_author_if_old_cap_prefix() : void {
  * @return array Updated post data.
  */
 function update_post_author( $data, $postarr ) {
-	if ( ! function_exists( 'get_coauthors' ) ) {
+	if ( wp_is_post_revision( $postarr['ID'] ) || ! function_exists( 'get_coauthors' ) ) {
 		return $data;
 	}
 
@@ -112,7 +112,7 @@ function update_post_author( $data, $postarr ) {
 	$author_login = str_replace( 'cap-', '', reset( $coauthors )->linked_account );
 	$author_id    = get_user_by( 'login', $author_login )->ID;
 
-	if ( ! wp_is_post_revision( $postarr['ID'] ) ) {
+	if ( ! empty( $author_id ) ) {
 		$data['post_author'] = $author_id;
 	}
 


### PR DESCRIPTION
This change tries to fix the post author in the JetPack email notifications by updating the `post_author` with the first Co-Authors Plus plugin author assigned to a post. This assumes that JetPack is looking for the `post_author` value when creating the email notification for a post.

**To Do:**
- [ ] Test with with JetPack email by subscribing to a post and checking the post author, however the email subscription functionality doesn't seem to be working on the Dev server.

**Testing Instructions:**
1. Create a new post and add another user as a guest author under the "Authors" sidebar panel, then remove yourself from the list before publishing it.
2. Once the post is published, copy the post ID from the editor URL.
3. On a terminal window in the Altis Dashboard check the `post_author` with the following command: `wp post get {ID}` replacing `{ID}` with the post ID you copied above.
4. Check that the `post_author` value contains the ID of the guest author and not yours.

For humanmade/wikimedia#887