### PR TITLE
868: Fix the Interconnection Theme Table of Contents Sidebar

### DIFF
--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -20,10 +20,10 @@
 		</div>
 
 		<?php
-		$pattern_heading = '/<h2 id="(.*?)">(.*?)<\/h2>/';
+		$pattern_heading = '/<h2 class="(.*?)" id="(.*?)">(.*?)<\/h2>/';
 		preg_match_all( $pattern_heading, get_the_content(), $matches );
-		$ids      = $matches[1];
-		$headings = $matches[2];
+		$ids      = $matches[2];
+		$headings = $matches[3];
 		?>
 
 		<div class="toc">


### PR DESCRIPTION
This change fixes the Interconnection theme table of contents bug by including the heading class parameter in the REGEX formula when selecting the TOC headings.

For humanmade/wikimedia#868

**Testing Instructions:**

1. Go to a page using Heading blocks (e.g., https://blog-wikimedia-org-develop.go-vip.net/editorial-guidelines/).
2. Edit the page and add an HTML anchor under "Advanced" in the Heading block sidebar.
3. Save the page and view.
4. Check that the Table of Contents sidebar populates correctly with all the headings that were assigned an anchor.

**Note:** The logic for the TOC sidebar **only works with H2 level headings**.