### PR TITLE
882 : Paragraphs that follow an image block without a caption don't have proper margin

### DIFF
--- a/sass/8-site/primary/_posts-and-pages.scss
+++ b/sass/8-site/primary/_posts-and-pages.scss
@@ -6,10 +6,6 @@
 	display: none;
 }
 
-body {
-	background-color: #f7e912;
-}
-
 // for single
 article.post {
 
@@ -47,6 +43,7 @@ article.post {
 
 		figure {
 			text-align: center;
+			margin-bottom: 1em;
 		}
 
 		figure.size-large:not(.is-resized),

--- a/sass/8-site/primary/_posts-and-pages.scss
+++ b/sass/8-site/primary/_posts-and-pages.scss
@@ -6,6 +6,10 @@
 	display: none;
 }
 
+body {
+	background-color: #f7e912;
+}
+
 // for single
 article.post {
 


### PR DESCRIPTION
This is a simple quick fix to add spacing to figure tag.